### PR TITLE
wip irgen for sildifferentiabilitywitness

### DIFF
--- a/include/swift/SIL/SILDifferentiabilityWitness.h
+++ b/include/swift/SIL/SILDifferentiabilityWitness.h
@@ -75,7 +75,14 @@ private:
       autoDiffConfig({parameterIndices, resultIndices, derivativeGenSig}),
       jvp(jvp), vjp(vjp), serialized(isSerialized), attribute(attribute) {}
 
+  SILDifferentiabilityWitness(const SILDifferentiabilityWitness&) = delete;
+  SILDifferentiabilityWitness& operator=(const SILDifferentiabilityWitness&)
+      = delete;
+
 public:
+
+  ~SILDifferentiabilityWitness();
+
   static SILDifferentiabilityWitness *create(
       SILModule &module, SILLinkage linkage, SILFunction *originalFunction,
       IndexSubset *parameterIndices, IndexSubset *resultIndices,

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1067,12 +1067,9 @@ void IRGenerator::emitGlobalTopLevel() {
   // SWIFT_ENABLE_TENSORFLOW
   // Emit differentiability witnesses.
   for (auto &dw : PrimaryIGM->getSILModule().getDifferentiabilityWitnessList()) {
-    // NOTE: Uncommenting this will cause test failures
-#if 0
     // TODO: Which IRGenModule to use? The one containing JVP or VJP
     CurrentIGMPtr IGM = getGenModule(dw.getOriginalFunction()->getDeclContext());
     IGM->emitSILDifferentiabilityWitness(&dw);
-#endif
   }
   // SWIFT_ENABLE_TENSORFLOW
   
@@ -2717,12 +2714,15 @@ IRGenModule::getAddrOfLLVMVariable(LinkEntity entity,
   LinkInfo link = LinkInfo::get(*this, entity, forDefinition);
 
   // Clang may have defined the variable already.
-  if (auto existing = Module.getNamedGlobal(link.getName()))
+  if (auto existing = Module.getNamedGlobal(link.getName())) {
     return getElementBitCast(existing, defaultType);
+  }
 
   // If we're not defining the object now, forward declare it with the default
   // type.
-  if (!definitionType) definitionType = defaultType;
+  if (!definitionType) {
+    definitionType = defaultType;
+  }
 
   // Create the variable.
   auto var = createVariable(*this, link, definitionType,

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2208,23 +2208,20 @@ void IRGenModule::emitSILDifferentiabilityWitness(
   // Build the witness table.
   ConstantInitBuilder builder(*this);
   auto diffWitnessContents = builder.beginStruct();
+  llvm::dbgs() << "get addr of orig " << dw->getOriginalFunction() << "\n";
+  dw->getOriginalFunction()->dump();
   auto *origFnAddr = getAddrOfSILFunction(dw->getOriginalFunction(), NotForDefinition);
+  llvm::dbgs() << "get addr of jvp " << dw->getJVP() << "\n";
+  //dw->getJVP()->dump();
   auto *jvpFnAddr = getAddrOfSILFunction(dw->getJVP(), NotForDefinition);
+  llvm::dbgs() << "get addr of vjp " << dw->getVJP() << "\n";
+  //dw->getVJP()->dump();
   auto *vjpFnAddr = getAddrOfSILFunction(dw->getVJP(), NotForDefinition);
-  llvm::errs() << "DIFF WITNESS REFERENCES\n";
-  origFnAddr->dump();
-  jvpFnAddr->dump();
-  vjpFnAddr->dump();
-  diffWitnessContents.addRelativeAddress(origFnAddr);
-  diffWitnessContents.addRelativeAddress(jvpFnAddr);
-  diffWitnessContents.addRelativeAddress(vjpFnAddr);
-  auto diffWitnessGlobal =
-    diffWitnessContents.finishAndCreateGlobal("differentiability_witness",
-                                              getPointerAlignment(),
-                                              /*constant*/ true);
-  llvm::errs() << "DIFF WITNESS GLOBAL\n";
-  diffWitnessGlobal->dump();
-  // getAddrOfDifferentiabilityWitness(<#SILFunction *original#>, <#const AutoDiffConfig config#>)
+  diffWitnessContents.addBitCast(origFnAddr, Int8PtrTy);
+  diffWitnessContents.addBitCast(jvpFnAddr, Int8PtrTy);
+  diffWitnessContents.addBitCast(vjpFnAddr, Int8PtrTy);
+  auto diffWitnessFuture = diffWitnessContents.finishAndCreateFuture();
+  getAddrOfDifferentiabilityWitness(dw->getOriginalFunction(), dw->getAutoDiffConfig(), diffWitnessFuture);
 #if 0
   WitnessTableBuilder wtableBuilder(*this, wtableContents, wt);
   wtableBuilder.build();

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -426,6 +426,10 @@ public:
 
   unsigned getFunctionOrder(SILFunction *F) {
     auto it = FunctionOrder.find(F);
+    if (it == FunctionOrder.end()) {
+      llvm::dbgs() << "no order for\n";
+      F->dump();
+    }
     assert(it != FunctionOrder.end() &&
            "no order number for SIL function definition?");
     return it->second;

--- a/lib/SIL/SILDifferentiabilityWitness.cpp
+++ b/lib/SIL/SILDifferentiabilityWitness.cpp
@@ -25,6 +25,13 @@ SILDifferentiabilityWitness *SILDifferentiabilityWitness::create(
   auto *diffWitness = new (module) SILDifferentiabilityWitness(
       module, linkage, originalFunction, parameterIndices, resultIndices,
       derivativeGenSig, jvp, vjp, isSerialized, attribute);
+  //llvm::dbgs() << "construct dw for " << originalFunction->getName() << "\n";
+  //if (originalFunction)
+  //  originalFunction->incrementRefCount();
+  //if (jvp)
+  //  jvp->incrementRefCount();
+  //if (vjp)
+  //  vjp->incrementRefCount();
   // Register the differentiability witness in the module.
   auto config = diffWitness->getAutoDiffConfig();
 #if 0
@@ -41,6 +48,17 @@ SILDifferentiabilityWitness *SILDifferentiabilityWitness::create(
   diffWitness->dump();
 #endif
   return diffWitness;
+}
+
+SILDifferentiabilityWitness::~SILDifferentiabilityWitness() {
+  //llvm::dbgs() << "destruct dw for " << originalFunction->getName() << "\n";
+  //if (originalFunction)
+  //  originalFunction->decrementRefCount();
+  //if (jvp)
+  //  jvp->decrementRefCount();
+  //if (vjp)
+  //  vjp->decrementRefCount();
+  //llvm::dbgs() << "finished destruct dw for " << originalFunction->getName() << "\n";
 }
 
 SILDifferentiabilityWitnessKey SILDifferentiabilityWitness::getKey() const {

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -206,6 +206,9 @@ SILFunction::~SILFunction() {
     BB.InstList.clearAndLeakNodesUnsafely();
   }
 
+  if (RefCount > 0)
+    llvm::dbgs() << getName() << "\n";
+
   assert(RefCount == 0 &&
          "Function cannot be deleted while function_ref's still exist");
 }

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -606,6 +606,14 @@ class DeadFunctionElimination : FunctionLivenessComputation {
       }
     }
 
+    // SWIFT_ENABLE_TENSORFLOW
+    // Check differentiable function witness entries.
+    for (auto &dw : Module->getDifferentiabilityWitnessList()) {
+      llvm::dbgs() << "ensure alive for dw of " << dw.getOriginalFunction()->getName() << "\n";
+      ensureAlive(dw.getOriginalFunction());
+      ensureAlive(dw.getJVP());
+      ensureAlive(dw.getVJP());
+    }
   }
 
   /// Removes all dead methods from vtables and witness tables.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2678,6 +2678,7 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   registerSILAbbr<SILInstLinearFunctionLayout>();
   registerSILAbbr<SILInstDifferentiableFunctionExtractLayout>();
   registerSILAbbr<SILInstLinearFunctionExtractLayout>();
+  registerSILAbbr<SILInstDifferentiabilityWitnessFunctionLayout>();
   // SWIFT_ENABLE_TENSORFLOW END
 
   // Register the abbreviation codes so these layouts can exist in both


### PR DESCRIPTION
This is my work-in-progress IRGen for SILDifferentiabilityWitness, as a patch on top of your e2e branch.

Do not compile the stdlib with this patch. It will fail. Instead, you must have an existing stdlib before you apply the patch, then you must recompile only the swift compiler.

Super simple derivative registration through SILDifferentiabilityWitness works end-to-end, for example:
```
public func foo(_ x: Float) -> Float { x }

@differentiating(foo)
public func vjpFoo(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
  (x, { 10 * $0 })
}

let g = gradient(at: 0, in: foo)
print(g)
```

More complicated stuff (the stdlib for example) seems to run into some problem where VJP SILFunctions are getting deleted by someone before the SILDifferentiabilityWitness gets emitted, causing assertion failures while trying to emit the SILDifferentiabilityWitness.